### PR TITLE
transient element index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.2.23
+
+* Fixed bug [Different behavior between Tinkergraph, Neo4j (embedded) and neo4j-gremlin-bolt](https://github.com/SteelBridgeLabs/neo4j-gremlin-bolt/issues/52)
+
 ## 0.2.22
 
 * Fixed bug in Update statement when removing Edge/Vertex property value

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-gremlin-bolt</artifactId>
-    <version>0.2.22</version>
+    <version>0.2.23</version>
     <packaging>jar</packaging>
     <name>SteelBridge Labs Neo4J Gremlin (Bolt) integration</name>
     <description>SteelBridge Labs Neo4J Gremlin (Bolt) integration</description>


### PR DESCRIPTION
This pull request fixes #52, creates transient element index to be able to retrieve them using the graph.vertices() and graph.edges() methods