### PR TITLE
added tests for more types in a uniform manner #80

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>neo4j-gremlin-bolt</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
     <packaging>jar</packaging>
     <name>SteelBridge Labs Neo4J Gremlin (Bolt) integration</name>
     <description>SteelBridge Labs Neo4J Gremlin (Bolt) integration</description>

--- a/src/main/java/com/steelbridgelabs/oss/neo4j/structure/Neo4JBoltSupport.java
+++ b/src/main/java/com/steelbridgelabs/oss/neo4j/structure/Neo4JBoltSupport.java
@@ -19,7 +19,7 @@
 package com.steelbridgelabs.oss.neo4j.structure;
 
 import org.apache.tinkerpop.gremlin.structure.Property;
-
+import org.neo4j.driver.v1.types.Point;
 import java.util.Objects;
 
 /**
@@ -33,8 +33,11 @@ final class Neo4JBoltSupport {
     static void checkPropertyValue(Object value) {
         Objects.requireNonNull(value, "value cannot be null");
         // check for supported types, TODO: Bolt supports List and Map values
-        if (value instanceof Boolean || value instanceof Long || value instanceof Double || value instanceof String)
-            return;
+        if (value instanceof Boolean) return;
+        if (value instanceof Long) return;
+        if (value instanceof Double) return;
+        if (value instanceof String) return;
+        if (value instanceof Point) return;
         // throw exception
         throw Property.Exceptions.dataTypeOfPropertyValueNotSupported(value);
     }

--- a/src/test/java/com/steelbridgelabs/oss/neo4j/structure/Neo4JPropertySamples.java
+++ b/src/test/java/com/steelbridgelabs/oss/neo4j/structure/Neo4JPropertySamples.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2016 SteelBridge Laboratories, LLC.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  For more information: http://steelbridgelabs.com
+ */
+
+package com.steelbridgelabs.oss.neo4j.structure;
+
+public enum Neo4JPropertySamples {
+    BOOL("test-bool", true),
+    LONG("test-long", 1L),
+    DOUBLE("test-double", 4.0),
+    STRING("test-string", "this is a test"),
+    POINT("test-point", 6.28318);
+
+    public String title;
+    public Object value;
+    public Class<?> clazz;
+
+    private Neo4JPropertySamples(String title, Object value) {
+        this.title = title;
+        this.value = value;
+        this.clazz = value.getClass();
+    }
+
+}

--- a/src/test/java/com/steelbridgelabs/oss/neo4j/structure/Neo4JVertexWhileAddingPropertyValueTest.java
+++ b/src/test/java/com/steelbridgelabs/oss/neo4j/structure/Neo4JVertexWhileAddingPropertyValueTest.java
@@ -18,6 +18,7 @@
 
 package com.steelbridgelabs.oss.neo4j.structure;
 
+import javafx.util.Pair;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.VertexProperty;
@@ -31,7 +32,9 @@ import org.neo4j.driver.v1.Values;
 import org.neo4j.driver.v1.types.Node;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * @author Rogelio J. Baucells
@@ -77,16 +80,26 @@ public class Neo4JVertexWhileAddingPropertyValueTest {
         Mockito.when(node.keys()).thenAnswer(invocation -> Collections.emptyList());
         Mockito.when(provider.generate()).thenAnswer(invocation -> 2L);
         Mockito.when(provider.fieldName()).thenAnswer(invocation -> "id");
+
+
         Neo4JVertex vertex = new Neo4JVertex(graph, session, provider, provider, node);
         // act
-        VertexProperty<?> result = vertex.property(VertexProperty.Cardinality.single, "test", 1L);
+        HashMap<Neo4JPropertySamples, VertexProperty<?>> results = new HashMap<>(Neo4JPropertySamples.values().length);
+        for ( Neo4JPropertySamples sam : Neo4JPropertySamples.values() ) {
+            results.put(sam, vertex.property(VertexProperty.Cardinality.single, sam.title, sam.value));
+        }
+
         // assert
-        Assert.assertNotNull("Failed to add property to vertex", result);
-        Assert.assertTrue("Property value is not present", result.isPresent());
-        Assert.assertTrue("Failed to set vertex as dirty", vertex.isDirty());
-        Assert.assertEquals("Invalid property key", result.key(), "test");
-        Assert.assertEquals("Invalid property value", result.value(), 1L);
-        Assert.assertEquals("Invalid property element", result.element(), vertex);
+        for ( Map.Entry<Neo4JPropertySamples,VertexProperty<?>> entry : results.entrySet() ) {
+            Neo4JPropertySamples key = entry.getKey();
+            VertexProperty<?> result = entry.getValue();
+            Assert.assertNotNull("Failed to add property to vertex", result);
+            Assert.assertTrue("Property value is not present", result.isPresent());
+            Assert.assertTrue("Failed to set vertex as dirty", vertex.isDirty());
+            Assert.assertEquals("Invalid property key", result.key(), key.title);
+            Assert.assertEquals("Invalid property value", result.value(), key.value);
+            Assert.assertEquals("Invalid property element", result.element(), vertex);
+        }
     }
 
     @Test

--- a/src/test/java/com/steelbridgelabs/oss/neo4j/structure/Neo4JVertexWhileRollbackTest.java
+++ b/src/test/java/com/steelbridgelabs/oss/neo4j/structure/Neo4JVertexWhileRollbackTest.java
@@ -32,6 +32,8 @@ import org.neo4j.driver.v1.Values;
 import org.neo4j.driver.v1.types.Node;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Rogelio J. Baucells
@@ -78,13 +80,21 @@ public class Neo4JVertexWhileRollbackTest {
         Mockito.when(provider.generate()).thenAnswer(invocation -> 2L);
         Mockito.when(provider.fieldName()).thenAnswer(invocation -> "id");
         Neo4JVertex vertex = new Neo4JVertex(graph, session, provider, provider, node);
-        vertex.property("key1", "value2");
+
         // act
+        Map<Neo4JPropertySamples, VertexProperty<?>> results = new HashMap<>(Neo4JPropertySamples.values().length);
+        for ( Neo4JPropertySamples sam : Neo4JPropertySamples.values() ) {
+            results.put(sam, vertex.property(sam.title, sam.value));
+        }
         vertex.rollback();
         // assert
-        Assert.assertNotNull(vertex.property("key1"));
-        Property<String> property = vertex.property("key1");
-        Assert.assertEquals("Failed to rollback property value", "value1", property.value());
+        for ( Map.Entry<Neo4JPropertySamples,VertexProperty<?>> entry : results.entrySet() ) {
+            Neo4JPropertySamples key = entry.getKey();
+            VertexProperty<?> result = entry.getValue();
+            Assert.assertNotNull(vertex.property(key.title));
+            Property<String> property = vertex.property(key.title);
+            Assert.assertEquals("Failed to rollback property value", key.value, property.value());
+        }
     }
 
     @Test
@@ -102,7 +112,11 @@ public class Neo4JVertexWhileRollbackTest {
         Mockito.when(provider.generate()).thenAnswer(invocation -> 2L);
         Mockito.when(provider.fieldName()).thenAnswer(invocation -> "id");
         Neo4JVertex vertex = new Neo4JVertex(graph, session, provider, provider, node);
-        vertex.property("key1", "value2");
+
+        Map<Neo4JPropertySamples, VertexProperty<?>> results = new HashMap<>(Neo4JPropertySamples.values().length);
+        for ( Neo4JPropertySamples sam : Neo4JPropertySamples.values() ) {
+            results.put(sam, vertex.property(sam.title, sam.value));
+        }
         // act
         vertex.rollback();
         // assert


### PR DESCRIPTION
This change:
* removes the warning that Points are not supported.
* adds an enum for property samples which are applied in those tests where setting multiple property types make sense. [in particular two looked appropriate to me, there may be others as well.]